### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
           token: ${{ secrets.github_token }}
       -
         name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.DOCKER_USERNAME }}/${{ secrets.REPO }}
           tags: "${{ steps.buildnumber.outputs.build_number }},${{ steps.extract_branch.outputs.branch }},${{ steps.extract_branch.outputs.branch }}-${{ steps.buildnumber.outputs.build_number }}"


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore